### PR TITLE
Fix bug of `search_list` type checking in get_post api

### DIFF
--- a/PyPtt/_api_get_post.py
+++ b/PyPtt/_api_get_post.py
@@ -69,7 +69,7 @@ def _get_post(api, board: str, post_aid: [str | None] = None, post_index: int = 
         check_value.check_type(search_condition, str, 'SearchCondition')
 
     if search_list is not None:
-        check_value.check_type(search_condition, list, 'search_list')
+        check_value.check_type(search_list, list, 'search_list')
 
     if len(board) == 0:
         raise ValueError(f'board error parameter: {board}')


### PR DESCRIPTION
**This is**
Bugfix

**Issue description**
A bug in get_post API which causes `search_list` parameter to not work.
This bug is related to `search_list` type checking, which causes the malfunction and reports following error messages:
```
~\anaconda3\lib\site-packages\PyPtt\_api_get_post.py in _get_post(api, board, post_aid, post_index, search_type, search_condition, search_list, query)
     70 
     71     if search_list is not None:
---> 72         check_value.check_type(search_condition, list, 'search_list')
     73 
     74     if len(board) == 0:

~\anaconda3\lib\site-packages\PyPtt\check_value.py in check_type(value, value_type, name)
     15             raise TypeError(f'[PyPtt] {name} {i18n.must_be_a_boolean}, but got {value}')
     16         else:
---> 17             raise TypeError(f'[PyPtt] {name} {i18n.must_be} {value_type}, but got {value}')
     18 
     19 

TypeError: [PyPtt] search_list 必須為 <class 'list'>, but got None
```

**How has this been tested?**
Execute the following sample codes without error messages.
```
target_board = 'Lifeismoney'
target_search_list = [
    (PyPtt.SearchType.KEYWORD, '美亞'),
    (PyPtt.SearchType.KEYWORD, '[情報]'),
]

newest_index = ptt_bot.get_newest_index(
    PyPtt.NewIndex.BOARD,
    board=target_board,
    search_list=target_search_list
)
post_info = ptt_bot.get_post(
    board=target_board,
    search_list=target_search_list,
    index=newest_index,
    query=True
)
```