### PR TITLE
chore: lock websockets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 progressbar2
-websockets
+websockets==12.0
 uao
 requests==2.32.0
 AutoStrEnum


### PR DESCRIPTION
前幾天websockets發布了13.0 但跟現在的程式碼似乎不相容 應該先鎖定websockets版本