### PR TITLE
fix: update import path of USER_AGENT for websockets 13

### DIFF
--- a/PyPtt/connect_core.py
+++ b/PyPtt/connect_core.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import websockets
 import websockets.exceptions
-import websockets.http
 
 import PyPtt
 from . import command
@@ -24,7 +23,14 @@ from . import log
 from . import screens
 from . import ssl_config
 
-websockets.http.USER_AGENT += f' PyPtt/{PyPtt.__version__}'
+try:
+    import websockets.http
+    websockets.http.USER_AGENT += f' PyPtt/{PyPtt.__version__}'
+    use_http11 = False
+except AttributeError:
+    import websockets.http11
+    websockets.http11.USER_AGENT += f' PyPtt/{PyPtt.__version__}'
+    use_http11 = True
 
 ssl_context = None
 
@@ -203,7 +209,7 @@ class API(object):
                         loop = asyncio.new_event_loop()
                         asyncio.set_event_loop(loop)
 
-                    log.logger.debug('USER_AGENT', websockets.http.USER_AGENT)
+                    log.logger.debug('USER_AGENT', websockets.http11.USER_AGENT if use_http11 else websockets.http.USER_AGENT)
                     self._core = asyncio.get_event_loop().run_until_complete(
                         websockets.connect(
                             websocket_host,


### PR DESCRIPTION
websockets.http is fully deprecated in websockets 13 per https://github.com/python-websockets/websockets/commit/a7a5042bed89b96fa2e391f3be0e255a59bffb0a

As a result, USER_AGENT is moved to websockets.http11 in https://github.com/python-websockets/websockets/commit/bbb316155a5aeb719f262873a5b29a98c19b25d9

As a result, this commit updates the import path of USER_AGENT to allow PyPtt to be executed with websockets 13.

TEST: run `python3 -c 'import PyPtt'` with websockets 13 installed.