### PR TITLE
Fix Potential TypeError in `get_post()`

### DIFF
--- a/PyPtt/_api_get_post.py
+++ b/PyPtt/_api_get_post.py
@@ -50,7 +50,7 @@ def get_post(api, board: str, aid: Optional[str] = None, index: Optional[int] = 
     if len(board) == 0:
         raise ValueError(f'board error parameter: {board}')
 
-    if index > 0 and aid is not None:
+    if (index is not None and index > 0) and aid is not None:
         raise ValueError('wrong parameter index and aid can\'t both input')
 
     if aid is not None:


### PR DESCRIPTION
## Description
This PR prevents a potential `TypeError` by ensuring that `index` is not `None` before performing a comparison.

## Issue
The `get_post()` API, when called with an `aid` in the following example, would result in the error `TypeError: '>' not supported between instances of 'NoneType' and 'int'`:

## Example
```python
import PyPtt

ptt_bot = PyPtt.API()
try:
    # ... login ...
    post_info = ptt_bot.get_post('Python', aid='1TJH_XY0')
    # ... do something ...
finally:
    ptt_bot.logout()