### PR TITLE
feat: 偵測 PTT 兩階段驗證(2FA)，改丟明確的 TwoFactorAuthRequired

### DIFF
--- a/PyPtt/PTT.py
+++ b/PyPtt/PTT.py
@@ -230,6 +230,7 @@ class API:
 
         Raises:
             LoginError: 登入失敗。
+            TwoFactorAuthRequired: 偵測到兩階段驗證畫面，PyPtt 無法自動完成驗證。
             WrongIDorPassword: 帳號或密碼錯誤。
             OnlySecureConnection: 只能使用安全連線。
             ResetYourContactEmail: 請先至信箱設定連絡信箱。
@@ -242,6 +243,8 @@ class API:
             try:
                 ptt_bot.login(
                     ptt_id='ptt_id', ptt_pw='ptt_pw', kick_other_session=True)
+            except PyPtt.TwoFactorAuthRequired:
+                print('偵測到兩階段驗證，請先手動登入完成驗證')
             except PyPtt.LoginError:
                 print('登入失敗')
             except PyPtt.WrongIDorPassword:

--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.5'
+__version__ = '2.3.6'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_loginout.py
+++ b/PyPtt/_api_loginout.py
@@ -97,6 +97,8 @@ def login(api, ptt_id: str, ptt_pw: str, kick_other_session: bool) -> None:
         connect_core.TargetUnit('密碼正確'),
         connect_core.TargetUnit('您想刪除其他重複登入的連線嗎', response=kick_other_login_response),
         connect_core.TargetUnit('◆ 您的註冊申請單尚在處理中', response=command.enter, handler=register_processing),
+        # 需排在「任意鍵」等泛用 catch-all 之前, 否則會被搶先命中而吃不到這條。
+        connect_core.TargetUnit('兩階段', break_detect=True, exceptions_=exceptions.TwoFactorAuthRequired()),
         connect_core.TargetUnit('任意鍵', response=' '),
         connect_core.TargetUnit('正在更新與同步線上使用者及好友名單'),
         connect_core.TargetUnit('【分類看板】', response=command.go_main_menu),

--- a/PyPtt/exceptions.py
+++ b/PyPtt/exceptions.py
@@ -38,6 +38,16 @@ class LoginError(Error):
         return self.message
 
 
+# 繼承 LoginError 以維持既有 `except LoginError` 呼叫端的相容性。
+# PyPtt 不實作 TOTP 自動輸入, 這裡只負責偵測畫面並指路。
+class TwoFactorAuthRequired(LoginError):
+    def __init__(self):
+        self.message = i18n.two_factor_auth_required
+
+    def __str__(self):
+        return self.message
+
+
 class NoFastComment(Error):
     def __init__(self):
         self.message = i18n.no_fast_comment

--- a/PyPtt/lang_en_US.py
+++ b/PyPtt/lang_en_US.py
@@ -110,6 +110,14 @@ string_data = {
     "success": "Success",
     "title": "Title",
     "transaction_cancelled": "The transaction is cancelled!",
+    "two_factor_auth_required": (
+        "This account has two-factor authentication (2FA) enabled, and PyPtt cannot "
+        "complete the verification automatically. PTT's 2FA can be configured to only "
+        "require verification from new IPs, so logging in again from the same IP will "
+        "skip it. Please first manually log in to PTT from this machine using a regular "
+        "BBS client and complete one 2FA verification; afterwards this machine's IP will "
+        "be considered verified, and you can then log in with PyPtt."
+    ),
     "unregistered_user_cant_use_all_api": "Unregistered UserField Can't Use All API",
     "unregistered_user_cant_use_this_api": "Unregistered UserField Can't Use This API",
     "update_remote_version": "Fetching latest version",

--- a/PyPtt/lang_zh_TW.py
+++ b/PyPtt/lang_zh_TW.py
@@ -110,6 +110,12 @@ string_data = {
     "success": "成功",
     "title": "標題",
     "transaction_cancelled": "交易取消!",
+    "two_factor_auth_required": (
+        "此帳號已啟用兩階段驗證(2FA), PyPtt 無法自動完成驗證。"
+        "PTT 的兩階段驗證可設定為「僅新 IP 需要驗證」, 同一 IP 再次登入時會跳過驗證。"
+        "請先在這台機器上使用一般 BBS 客戶端手動登入 PTT 並完成一次兩階段驗證, "
+        "之後這台機器的 IP 即可被視為已驗證, 再用 PyPtt 登入。"
+    ),
     "unregistered_user_cant_use_all_api": "未註冊使用者，將無法使用全部功能",
     "unregistered_user_cant_use_this_api": "未註冊使用者，無法使用此功能",
     "update_remote_version": "確認最新版本",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 ====================
 | 這裡寫著 PyPtt 的故事。
 
+| 2026.08.08 新增兩階段驗證(2FA)畫面偵測，登入時遇到 2FA 會拋出 ``TwoFactorAuthRequired``（繼承自 ``LoginError``）。
 | 2026.07.26 移除樂透 API（``get_lottery`` / ``bet_lottery``）與相關的 ``LotteryField`` / ``LotteryOptionField`` / ``LotteryBetField`` / ``NoSuchLottery``。這是 breaking change：樂透畫面同時違反 ``TargetUnit`` 螢幕比對的三個前提（畫面字串唯一標識狀態、送出後必有回應、按鍵不會被中間層吃掉），維護成本高於價值。
 | 2026.07.21 新增 :doc:`api/set_signature_file` API（``set_signature_file``），可更新使用者名片檔（plan）。
 | 2026.07.19 內嵌 pyUAO Big5-UAO 編碼器，移除對外部 ``uao`` 套件的依賴。

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -20,6 +20,13 @@
 
     登入失敗。
 
+.. py:exception:: PyPtt.exceptions.TwoFactorAuthRequired
+    :module: PyPtt
+
+    偵測到 PTT 的兩階段驗證畫面。PyPtt 無法自動完成驗證，僅能偵測並中斷登入流程。PTT 可設定為
+    僅新 IP 需要驗證，同一 IP 再次登入時會跳過此步驟；建議先在同一台機器上用一般 BBS 客戶端手動
+    登入一次以完成驗證。繼承自 :py:exc:`PyPtt.exceptions.LoginError`。
+
 .. py:exception:: PyPtt.exceptions.NoFastComment
     :module: PyPtt
 


### PR DESCRIPTION
## 背景

PTT 於 2026-08-04 上線 TOTP 兩階段驗證（[pttbbs commit `12ceb7b`](https://github.com/ptt/pttbbs/commit/12ceb7b6b3e402080204fcada3ad1f41107a33ca)），使用者自選開啟，非全站強制。

PyPtt 的登入 `target_list` 沒有任何一條命中 2FA 提示畫面，實測結果是逾時 10 秒後 `return -1`，最終落到 `_api_loginout.py` 的最終把關丟出泛用的 `LoginError`。使用者只會看到一個分不出是密碼錯誤還是 2FA 的錯誤。

## 改了什麼

只做偵測與明確報錯，**不實作 TOTP 自動輸入**。

- `exceptions.py` 新增 `TwoFactorAuthRequired`，**繼承 `LoginError`**，既有 `except LoginError` 的呼叫端不會壞
- `_api_loginout.py` 的 `target_list` 加入比對「兩階段」的條目。此二字同時存在於 PTT 的「此帳號需要兩階段驗證。」與「請輸入兩階段(2FA)驗證碼(6位限時數字 或 8位救援碼):」兩個提示，單一字串即可覆蓋
- 訊息走既有 i18n 機制（`lang_zh_TW.py` / `lang_en_US.py`），中英文皆說明：PTT 的 2FA 可設為僅新 IP 需驗證（`U_2FA_NEWIP`），同一 IP 再次登入會跳過，故建議先從同一台機器用一般 BBS 客戶端手動登入完成一次驗證
- 文件：`docs/exceptions.rst` 條目、`login()` docstring 的 `Raises` 與範例、`docs/changelog.rst`

## 兩個順序坑

兩處都是「父類/catch-all 會搶先攔截」的同一種形狀：

1. `target_list` 是首個命中即停，「兩階段」必須排在「任意鍵」catch-all **之前**
2. docstring 範例中 `except TwoFactorAuthRequired` 必須排在 `except LoginError` **之前**，因為前者繼承後者

## 驗證

- self-check 腳本：行為面（假 2FA 畫面命中並拋出正確例外、正常主選單不誤命中）＋ 用 `inspect.getsource(login)` 讀**真實** `target_list` 檢查順序 ＋ 中英文訊息取值不同。附反證測試：把「兩階段」搬到「任意鍵」之後，腳本會 FAIL
- Sphinx 文件建置成功，0 warnings，產物含新例外且交叉引用正常解析
- flake8 無新增問題
- **真實環境驗證**：`tests/conftest.py` 會用真實帳密登入正式 PTT，該測試帳號正好啟用了 2FA。改動前 15 個測試各卡約 60 秒後噴泛用 `LoginError`；改動後秒噴 `TwoFactorAuthRequired`。等於拿真實 PTT 畫面做過端對端驗證，非僅假字串比對

## 未涵蓋

- 沒有 TOTP 自動輸入。要無人值守跑，需為 `login()` 加 `totp_secret` 參數
- 8 碼救援碼一次性、用完即失效，不適合程式化重複登入

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UbZgc9a53f3sLyAg3DNbF
