### PR TITLE
fix: 相容 PTT 主選單狀態列的短格式（登入判定、get_time、呼叫器狀態）

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.6'
+__version__ = '2.3.7'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_call_status.py
+++ b/PyPtt/_api_call_status.py
@@ -1,9 +1,23 @@
+import re
+
 from . import command
 from . import connect_core
 from . import data_type
 from . import exceptions
 from . import log
 from . import screens
+
+
+# 狀態列有 '[呼叫器]打開' 與 '呼叫器關閉' 兩種寫法, 中括號不保證存在。
+_call_status_pattern = re.compile(r'呼叫器[\]\s]*(打開|拔掉|防水|好友|關閉)')
+
+_call_status_map = {
+    '打開': data_type.CallStatus.ON,
+    '拔掉': data_type.CallStatus.UNPLUG,
+    '防水': data_type.CallStatus.WATERPROOF,
+    '好友': data_type.CallStatus.FRIEND,
+    '關閉': data_type.CallStatus.OFF,
+}
 
 
 def get_call_status(api) -> data_type.CallStatus:
@@ -17,34 +31,21 @@ def get_call_status(api) -> data_type.CallStatus:
     cmd = ''.join(cmd_list)
 
     target_list = [
-        connect_core.TargetUnit('[呼叫器]打開', log_level=log.DEBUG, break_detect=True),
-        connect_core.TargetUnit('[呼叫器]拔掉', log_level=log.DEBUG, break_detect=True),
-        connect_core.TargetUnit('[呼叫器]防水', log_level=log.DEBUG, break_detect=True),
-        connect_core.TargetUnit('[呼叫器]好友', log_level=log.DEBUG, break_detect=True),
-        connect_core.TargetUnit('[呼叫器]關閉', log_level=log.DEBUG, break_detect=True),
+        connect_core.TargetUnit(screens.Target.MainMenu, log_level=log.DEBUG, break_detect=True),
         connect_core.TargetUnit('★', log_level=log.DEBUG, response=cmd),
     ]
 
-    for i in range(2):
-        index = api.connect_core.send(cmd, target_list)
-        if index < 0:
-            if i == 0:
-                continue
-            raise exceptions.UnknownError('UnknownError')
-
-    if index == 0:
-        return data_type.CallStatus.ON
-    if index == 1:
-        return data_type.CallStatus.UNPLUG
-    if index == 2:
-        return data_type.CallStatus.WATERPROOF
-    if index == 3:
-        return data_type.CallStatus.FRIEND
-    if index == 4:
-        return data_type.CallStatus.OFF
+    for _ in range(2):
+        if api.connect_core.send(cmd, target_list) == 0:
+            break
+    else:
+        raise exceptions.UnknownError('UnknownError')
 
     ori_screen = api.connect_core.get_screen_queue()[-1]
-    raise exceptions.UnknownError(ori_screen)
+    result = _call_status_pattern.search(ori_screen)
+    if result is None:
+        raise exceptions.UnknownError(ori_screen)
+    return _call_status_map[result.group(1)]
 
 
 def set_call_status(api, call_status) -> None:

--- a/PyPtt/_api_get_time.py
+++ b/PyPtt/_api_get_time.py
@@ -38,7 +38,8 @@ def get_time(api) -> str:
     # 0:00
 
     for line in line_list:
-        if '星期' in line and '線上' in line and '我是' in line:
+        # 短格式的狀態列寫 '週三' 不是 '星期六', 所以不能比對 '星期'。
+        if '線上' in line and '我是' in line:
             result = pattern.search(line)
             if result is not None:
                 return result.group(0)

--- a/PyPtt/screens.py
+++ b/PyPtt/screens.py
@@ -63,10 +63,14 @@ def _str_pos_at_cells(line: str, cells: int) -> int:
 
 
 class Target:
+    # 正式站狀態列有兩種寫法, 短的那種會把逗號後的空格與中括號吃掉:
+    #   [5/23 星期六 16:40] [ 射手時 ]  線上27866人, 我是CodingMan   [呼叫器]打開
+    #   8/19週三22:35   [ 七夕 ]   線上30721人,我是DeepLearning 呼叫器關閉  (h)說明
+    # 只比對兩種格式共同的最短關鍵詞。
     MainMenu = [
         '離開，再見',
-        '人, 我是',
-        '[呼叫器]',
+        '我是',
+        '呼叫器',
     ]
 
     MainMenu_Exiting = [

--- a/tests/test_status_line.py
+++ b/tests/test_status_line.py
@@ -1,0 +1,41 @@
+"""PTT 主選單狀態列有長短兩種寫法, 兩種都必須認得。
+
+長: [5/23 星期六 16:40] [ 射手時 ]    線上27866人, 我是CodingMan      [呼叫器]打開
+短: 8/19週三22:35   [ 七夕 ]    線上30721人,我是DeepLearning 呼叫器關閉     (h)說明
+
+短的那種把逗號後的空格與呼叫器的中括號都吃掉了, 日期也從 '星期六' 縮成 '週三'。
+"""
+import re
+
+from PyPtt import data_type
+from PyPtt._api_call_status import _call_status_map, _call_status_pattern
+from PyPtt._api_get_time import pattern as time_pattern
+from PyPtt.screens import Target
+
+LONG = '[5/23 星期六 16:40] [ 射手時 ]    線上27866人, 我是CodingMan      [呼叫器]打開 '
+SHORT = '8/19週三22:35   [ 七夕 ]    線上30721人,我是DeepLearning 呼叫器關閉     (h)說明'
+
+MENU_BODY = '                      (G)oodbye         離開，再見…'
+
+
+def test_main_menu_markers_match_both_status_lines():
+    for status in (LONG, SHORT):
+        screen = MENU_BODY + '\n' + status
+        assert all(t in screen for t in Target.MainMenu), status
+
+
+def test_get_time_line_filter_and_pattern():
+    for status, expected in ((LONG, '16:40'), (SHORT, '22:35')):
+        assert '線上' in status and '我是' in status
+        assert time_pattern.search(status).group(0) == expected
+
+
+def test_call_status_pattern():
+    assert _call_status_map[_call_status_pattern.search(LONG).group(1)] == data_type.CallStatus.ON
+    assert _call_status_map[_call_status_pattern.search(SHORT).group(1)] == data_type.CallStatus.OFF
+
+
+def test_call_status_pattern_covers_every_state():
+    for word, expected in _call_status_map.items():
+        for form in (f'[呼叫器]{word}', f'呼叫器{word}'):
+            assert _call_status_map[_call_status_pattern.search(form).group(1)] == expected


### PR DESCRIPTION
## 問題

PTT 正式站的主選單狀態列有長短兩種寫法，短的那種把三個 PyPtt 寫死比對的關鍵詞都改掉了：

```
長: [5/23 星期六 16:40] [ 射手時 ]  線上27866人, 我是CodingMan   [呼叫器]打開
短: 8/19週三22:35   [ 七夕 ]   線上30721人,我是DeepLearning 呼叫器關閉  (h)說明
```

三處差異：`星期六` → `週三`、`人, 我是` 的空格消失、`[呼叫器]` 的中括號消失。

長格式取自 `tests/fixtures/vt100/main_menu.bin`（5/23 抓的），短格式是今天對真 PTT 實測抓到的。

## 影響

遇到短格式時 `screens.Target.MainMenu` 三個關鍵詞中有兩個落空，連鎖壞掉：

| 位置 | 症狀 |
|---|---|
| `_api_loginout.py:168` | `is_login` 判定失敗，密碼正確也丟 `LoginError` |
| `_api_get_time.py:41` | 卡在 `'星期' in line`，`get_time()` 回 `None` |
| `_api_call_status.py:20-24` | 五個 `[呼叫器]XX` 全部不中，丟 `UnknownError` |

`get_time` 與 `get_waterball` 另外也拿 `MainMenu` 當 break_detect，同樣受影響。

## 改法

只比對兩種格式的共同最短關鍵詞，不去猜哪一種才是「正確」的：

- `screens.Target.MainMenu`：`'人, 我是'` → `'我是'`、`'[呼叫器]'` → `'呼叫器'`
- `_api_get_time`：拿掉 `'星期'` 條件，保留 `'線上'` + `'我是'`
- `_api_call_status`：五個 `[呼叫器]XX` 沒有任何單一字串能同時吃到兩種格式（`[呼叫器]打開` 與 `呼叫器關閉` 沒有涵蓋兩者的連續子字串），所以改成等 `MainMenu` 出現後用 `re` 取狀態：`呼叫器[\]\s]*(打開|拔掉|防水|好友|關閉)`。順手移除原本 `for i in range(2)` 一定送兩次 `send` 的迴圈。

## 驗證

對真 PTT（`DeepLearning` 帳號）實跑：

```
login       : OK
get_time    : 22:39      ← 對得上牆上時鐘
call_status : OFF        ← 畫面確實是「呼叫器關閉」
get_user / get_board_info / logout : OK
```

新增 `tests/test_status_line.py`：4 個離線 case，新舊兩種狀態列都釘住，含五種呼叫器狀態 × 兩種格式的全組合。既有 218 個單元測試全過。

版本 2.3.6 → 2.3.7（PyPI 上已是 2.3.6）。

## 順帶發現，本 PR 沒動

1. `_api_call_status.py` 整個模組沒有任何呼叫者 —— `PTT.py` 沒有 `get_call_status` / `set_call_status` 入口，而 `set_call_status` 自己呼叫的 `api._get_call_status()` 在 `API` 上也不存在。等於死碼，這次只是讓它跟著新格式一致。
2. 本機跑 `pytest tests/` 現在整包會爆：`conftest.py` 的 autouse fixture 用 `PTT1_ID` 登入，而該帳號目前從新 IP 登入會要求 2FA。上面的單元測試是用 `--noconftest` 跑的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)